### PR TITLE
remove mention of nightly

### DIFF
--- a/install
+++ b/install
@@ -5,7 +5,6 @@
 #
 # If you know rust or have rust installed, you can build it with
 # `cargo build --release`
-# Note that nightly rust is required.
 
 set -u
 


### PR DESCRIPTION
I've seen after compiling on rust stable 1.51 that skim used to require nightly

Can we now remove this line ?